### PR TITLE
Set class_based for handlers organized in classes

### DIFF
--- a/aiohttp_validate/__init__.py
+++ b/aiohttp_validate/__init__.py
@@ -115,7 +115,10 @@ def validate(request_schema=None, response_schema=None):
                 class_based = True
                 request = args[0].request
             else:
-                class_based = False
+                if func.__name__ != func.__qualname__:
+                    class_based = True
+                else:
+                    class_based = False
                 request = args[-1]
 
             # Strictly expect json object here


### PR DESCRIPTION
This commit sets class_based variable both in the classbased views and handlers organized in classes cases:
https://docs.aiohttp.org/en/stable/web_quickstart.html#class-based-views
https://docs.aiohttp.org/en/stable/web_quickstart.html#organizing-handlers-in-classes
At the moment the library only supports class based views, issue https://github.com/dchaplinsky/aiohttp_validate/issues/154

This works for python 3, taken of this stack overflow's answer:
https://stackoverflow.com/a/54837483